### PR TITLE
Add keyboard tab icon and update mapping.json

### DIFF
--- a/src/icons/keyboard-tab.svg
+++ b/src/icons/keyboard-tab.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.00001 13.8871L14 8.88711V8.18L9.00001 3.18L8.2929 3.88711L12.4393 8.03355L2 8.03355L2 9.03355L12.4393 9.03355L8.2929 13.18L9.00001 13.8871Z" fill="#424242"/>
+<path d="M15 3H16V14H15V3Z" fill="#424242"/>
+</svg>

--- a/src/template/mapping.json
+++ b/src/template/mapping.json
@@ -575,5 +575,6 @@
   "copilot-warning": 60472,
   "python": 60473,
   "copilot-large": 60474,
-  "copilot-warning-large": 60475
+  "copilot-warning-large": 60475,
+  "keyboard-tab": 60476
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/template/mapping.json` file. The change adds a new mapping for the `keyboard-tab` identifier.

* [`src/template/mapping.json`](diffhunk://#diff-200ae9729f8368f37cbf056d138a9def5f65c6d4edd7d7ac1fb68324289c9d78L578-R579): Added a new mapping for the `keyboard-tab` identifier.