### PR TITLE
fix mapping.json to correct key name for extensions-large

### DIFF
--- a/src/template/mapping.json
+++ b/src/template/mapping.json
@@ -588,5 +588,5 @@
   "keyboard-tab-below": 60485,
   "git-pull-request-done": 60486,
   "mcp": 60487,
-  "extension-large": 60488
+  "extensions-large": 60488
 }


### PR DESCRIPTION
This pull request includes a minor change to the `src/template/mapping.json` file. The change corrects a typo in the key name from `"extension-large"` to `"extensions-large"` to ensure consistency.