### PR TITLE
Update release workflow to use PERSONAL_ACCESS_TOKEN for GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
@@ -57,7 +57,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
           asset_path: ./dist/codicon.ttf


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by replacing the `GITHUB_TOKEN` with a `PERSONAL_ACCESS_TOKEN` for better security and permissions management.

Changes in `.github/workflows/release.yml`:

* Updated the `GITHUB_TOKEN` to `PERSONAL_ACCESS_TOKEN` in the `create_release` step to use a personal access token for authentication.
* Updated the `GITHUB_TOKEN` to `PERSONAL_ACCESS_TOKEN` in the `upload-release-asset` step to ensure consistent token usage across release-related actions.