### PR TITLE
Update version to `0.0.44`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/codicons",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/codicons",
-      "version": "0.0.43",
+      "version": "0.0.44",
       "license": "CC-BY-4.0",
       "devDependencies": {
         "ansi-regex": ">=5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/codicons",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "fontVersion": "1.15",
   "description": "The icon font for Visual Studio Code",
   "license": "CC-BY-4.0",


### PR DESCRIPTION
Update the version of the @vscode/codicons package to `0.0.44` in both package.json and package-lock.json.