### PR TITLE
Add 'present' tag to share-window icon metadata

### DIFF
--- a/src/template/metadata.json
+++ b/src/template/metadata.json
@@ -2260,7 +2260,7 @@
     "description": "Share"
   },
   "share-window": {
-    "tags": ["window", "share", "screen", "multiple", "overlay", "collaborate", "display"],
+    "tags": ["window", "share", "screen", "multiple", "overlay", "collaborate", "display", "present"],
     "category": "layout",
     "description": "Share or present a window"
   },


### PR DESCRIPTION
Include a 'present' tag in the metadata for the share-window icon to enhance its categorization.